### PR TITLE
TG-131: Added Input to shared components

### DIFF
--- a/src/Components/Shared/Input/index.jsx
+++ b/src/Components/Shared/Input/index.jsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import styles from './input.module.css';
+
+const Input = ({ type, htmlForProp, label, register, name, error, width }) => {
+  return (
+    <div>
+      <label htmlFor={htmlForProp}>{label}</label>
+      <input style={{ width }} type={type} {...register(name)} />
+      {error && <p className={styles.error}>{error}</p>}
+    </div>
+  );
+};
+
+export default Input;

--- a/src/Components/Shared/Input/index.jsx
+++ b/src/Components/Shared/Input/index.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import styles from './input.module.css';
 
-const Input = ({ type, htmlForProp, label, register, name, error, width }) => {
+const Input = ({ type, htmlForPropAndLabel, register, name, error, width }) => {
   return (
     <div>
-      <label htmlFor={htmlForProp}>{label}</label>
-      <input style={{ width }} type={type} {...register(name)} />
+      <label htmlFor={htmlForPropAndLabel}>{htmlForPropAndLabel}</label>
+      <input style={{ width }} type={type} {...register(name)} name={name} />
       {error && <p className={styles.error}>{error}</p>}
     </div>
   );

--- a/src/Components/Shared/Input/input.module.css
+++ b/src/Components/Shared/Input/input.module.css
@@ -1,0 +1,13 @@
+input{
+  height: 36px;
+  width: 189.63px;
+  border-radius: 5px;
+  border: 1px solid #373867;
+  background: transparent;
+  box-shadow: 0px 5px 5px 0px rgba(0,0,0,0.19);
+  content:"\025be";
+}
+input[type=checkbox]{
+  height: 15px;
+  width: 15px;
+}


### PR DESCRIPTION
Here there is the Input shared component, it has the following props:
**_1. type:_** Where you can choose the type input (text, date, number and so on).
**_2. htmlForPropAndLabel:_** Where the htmlFor for accessibility is specified. It's has also de `Label` tag content
**_3. register:_** This is where you send the register of the Forms as a prop
**_4. name:_** Here you specify the `{...register(name)}` and the content for the `name` tag
**_5. error:_** The error that should show if it is needed
 **_6. width:_** The width of the input

It has **_NO_** functionality, it's just the component
(I tested it on the employee's tab and it worked fine)